### PR TITLE
Fix crash + prevent FML incompatibility error.

### DIFF
--- a/src/main/java/com/tfar/enchantedbookredesign/EnchantedBookRedesign.java
+++ b/src/main/java/com/tfar/enchantedbookredesign/EnchantedBookRedesign.java
@@ -13,12 +13,16 @@ import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
 import net.minecraftforge.fml.packs.ModFileResourcePack;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -32,6 +36,8 @@ public class EnchantedBookRedesign {
     private static ResourcePack internalResourcePack;
 
     public EnchantedBookRedesign() {
+        ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
+
         DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
             List<ModFileInfo> modFiles = ModList.get().getModFiles();
             for (ModFileInfo modFileInfo : modFiles){

--- a/src/main/java/com/tfar/enchantedbookredesign/mixin/ItemRendererMixin.java
+++ b/src/main/java/com/tfar/enchantedbookredesign/mixin/ItemRendererMixin.java
@@ -38,7 +38,7 @@ public class ItemRendererMixin {
 	//cancel the vanilla glint and render our own
 	@Inject(method = "getBuffer", at = @At("HEAD"), cancellable = true)
 	private static void tintedglint(IRenderTypeBuffer bufferIn, RenderType renderTypeIn, boolean isItemIn, boolean glintIn, CallbackInfoReturnable<IVertexBuilder> cir) {
-		if (glintIn && Hooks.stack.getItem() == Items.ENCHANTED_BOOK) {
+		if (glintIn && Hooks.stack != null && Hooks.stack.getItem() == Items.ENCHANTED_BOOK) {
 			IVertexBuilder builder2 = bufferIn.getBuffer(renderTypeIn);
 			cir.setReturnValue(builder2);
 			Hooks.renderTint = true;


### PR DESCRIPTION
There was a rare crash in the tintedglint method that should be solved with a null check.

Refer here for the FML Incompatibility error fix: https://mcforge.readthedocs.io/en/1.15.x/concepts/sides/#writing-one-sided-mods

The mod is a client-side mod but is registered as being required on the server, so causes an FML error to be displayed in the multiplayer menu on the client.